### PR TITLE
feat(logger): add customError function

### DIFF
--- a/src/logger/logger.js
+++ b/src/logger/logger.js
@@ -22,7 +22,7 @@ class Logger {
   static _validate(options) {
     Object.keys(options).forEach(key => {
       if (!allowedKeys.includes(key)) {
-        throw new Error('Only the following keys are allowed: formatter, output')
+        throw new Error('Only the following keys are allowed: formatter, output');
       }
     });
   }
@@ -37,6 +37,10 @@ class Logger {
 
   warnFromError(action, error, data = {}) {
     this.warn(action, Object.assign(this._getErrorDetails(error), data));
+  }
+
+  customError(severity, action, error, data = {}) {
+    logMethodFactory(severity).bind(this)(action, Object.assign(this._getErrorDetails(error), data));
   }
 
   timer() {
@@ -67,7 +71,7 @@ class Logger {
       error_stack: this._shortenStackTrace(error.stack),
       error_message: error.message,
       error_data: this._shortenData(error.data)
-    }
+    };
   }
 }
 

--- a/src/logger/logger.js
+++ b/src/logger/logger.js
@@ -31,16 +31,16 @@ class Logger {
     return this._enabled;
   }
 
+  customError(severity, action, error, data = {}) {
+    logMethodFactory(severity).bind(this)(action, Object.assign(this._getErrorDetails(error), data));
+  }
+
   fromError(action, error, data = {}) {
-    this.error(action, Object.assign(this._getErrorDetails(error), data));
+    this.customError('error', action, error, data);
   }
 
   warnFromError(action, error, data = {}) {
-    this.warn(action, Object.assign(this._getErrorDetails(error), data));
-  }
-
-  customError(severity, action, error, data = {}) {
-    logMethodFactory(severity).bind(this)(action, Object.assign(this._getErrorDetails(error), data));
+    this.customError('warn', action, error, data);
   }
 
   timer() {

--- a/src/logger/logger.spec.js
+++ b/src/logger/logger.spec.js
@@ -120,6 +120,61 @@ describe('Logger', function() {
     expect(logArguments.error_data.length).to.eql(3004);
   });
 
+  describe('#customError', function() {
+    it('should log error as the given severity with action', function() {
+      const error = new Error('failed');
+      error.data = { test: 'data' };
+
+      logger.customError('info', 'hi', error, { details: 'here' });
+
+      const logArguments = JSON.parse(console.log.args[0]);
+      expect(logArguments.name).to.eql('mongo');
+      expect(logArguments.action).to.eql('hi');
+      expect(logArguments.level).to.eql(30);
+      expect(logArguments.details).to.eql('here');
+
+      expect(logArguments.error_name).to.eql(error.name);
+      expect(logArguments.error_stack).to.eql(error.stack);
+      expect(logArguments.error_message).to.eql(error.message);
+      expect(logArguments.error_data).to.eql(JSON.stringify(error.data));
+    });
+
+    it('should not log error data when it is undefined', function() {
+      const error = new Error('failed');
+
+      logger.customError('warn', 'hi', error, { details: 'here' });
+
+      const logArguments = JSON.parse(console.log.args[0]);
+      expect(logArguments.name).to.eql('mongo');
+      expect(logArguments.action).to.eql('hi');
+      expect(logArguments.level).to.eql(40);
+      expect(logArguments.details).to.eql('here');
+
+      expect(logArguments.error_name).to.eql(error.name);
+      expect(logArguments.error_stack).to.eql(error.stack);
+      expect(logArguments.error_message).to.eql(error.message);
+      expect(logArguments).to.not.have.any.keys('error_data');
+    });
+
+    it('should log only 3000 character of data', function() {
+      const error = new Error('failed');
+      error.data = 'exactlyTen'.repeat(400);
+
+      logger.customError('error', 'hi', error, { details: 'here' });
+
+      const logArguments = JSON.parse(console.log.args[0]);
+      expect(logArguments.name).to.eql('mongo');
+      expect(logArguments.action).to.eql('hi');
+      expect(logArguments.level).to.eql(50);
+      expect(logArguments.details).to.eql('here');
+
+      expect(logArguments.error_name).to.eql(error.name);
+      expect(logArguments.error_stack).to.eql(error.stack);
+      expect(logArguments.error_message).to.eql(error.message);
+      expect(logArguments.error_data.length).to.eql(3004);
+    });
+  });
+
   describe('#configure', function() {
     it('should change format method', function() {
       const formattedOutput = '{"my":"method"}';


### PR DESCRIPTION
I had copied the tests from a similar method I found a couple of exciting things:
- Multiple expects per it block
- Seven expects from eight are the same in three tests
- Very hard to figure it out which tests belong to a specific method

Implementation:
- Extra methods with prototype extension and Class usage a little bit strange for me