### PR TITLE
feat(deps): use version ranges for direct dependencies

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-save-exact=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "@emartech/json-logger",
       "license": "MIT",
       "dependencies": {
-        "lodash": "4.17.21"
+        "lodash": "^4.17.21"
       },
       "devDependencies": {
         "@types/chai": "4.3.3",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,14 @@
     "access": "public"
   },
   "author": "Emartech",
-  "engines": {
-    "node": ">=14"
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/emartech/json-logger-js.git"
   },
+  "bugs": {
+    "url": "https://github.com/emartech/json-logger-js/issues"
+  },
+  "homepage": "https://github.com/emartech/json-logger-js#readme",
   "license": "MIT",
   "keywords": [
     "log",
@@ -26,6 +31,12 @@
     "debug",
     "json"
   ],
+  "engines": {
+    "node": ">=14"
+  },
+  "dependencies": {
+    "lodash": "^4.17.21"
+  },
   "devDependencies": {
     "@types/chai": "4.3.3",
     "@types/lodash": "4.14.198",
@@ -50,16 +61,5 @@
     "sinon-chai": "3.7.0",
     "ts-node": "10.9.1",
     "typescript": "4.8.4"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/emartech/json-logger-js.git"
-  },
-  "bugs": {
-    "url": "https://github.com/emartech/json-logger-js/issues"
-  },
-  "homepage": "https://github.com/emartech/json-logger-js#readme",
-  "dependencies": {
-    "lodash": "4.17.21"
   }
 }


### PR DESCRIPTION
A library shouldn't pin direct dependencies to allow consumers to upgrade to newer transient dependency versions, e.g. for security patches.
Dev dependencies should continue to be pinned.

See also [Renovate Docs](https://docs.renovatebot.com/dependency-pinning/#ranges-for-libraries). Our Renovate config applies the same approach: https://github.com/emartech/json-logger-js/blob/28f846bff85afbb4d8755fad83bbcde868fb28b4/renovate.json#L6