### PR TITLE
fix(package): improve filtering of published files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,0 @@
-*.spec.js
-*.spec.d.ts
-node_modules
-.idea
-examples
-src
-.eslintrc
-.prettierrc
-.github

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "@emartech/json-logger",
   "description": "Tiny and fast json logger with namespace support",
   "main": "dist/index.js",
+  "files": [
+    "dist",
+    "!**.spec.*"
+  ],
   "scripts": {
     "test": "mocha --require ts-node/register --extension ts ./src --recursive",
     "test:watch": "mocha --require ts-node/register --extension ts ./src --recursive --watch",


### PR DESCRIPTION
Currently, some files like `.nvmrc` & `renovate.json` are published which isn't intended.

Instead of using an `.npmignore` file, it's easier to filter the list of published files by using the [files](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#files) parameter in the `package.json`.